### PR TITLE
Update : vopt_manager.pl

### DIFF
--- a/vopt_manager.pl
+++ b/vopt_manager.pl
@@ -184,6 +184,7 @@ sub parse_lsmap {
     if ( $line =~ /(vhost\d+):(0x[^:]+):([^:]+):/ ) {
       warn whoami() . " parse NO vopt mapping:" .  $line if $debug;
       my $lparid = sprintf("%d", hex($2));
+      next if $lparid == 0;
       $$refvoptmap{$lparid}{'vhost'} = $1;
       $$refvoptmap{$lparid}{'vios'} = $vios;
     }


### PR DESCRIPTION
I propose to add the line 'next if $lparid == 0;' in the function "parse_lsmap"

If this line is not present, the script generates commands to create a cdrom to an lpar where lparid equals to 0.

Ex :

main:%voptmap = (
...
0 => {
       'vhost' => 'vhost24',
       'vios' => 'VIOSERVER2'
},
...
# CREATE VIRTUAL OPTICAL DEVICES
# 
# command to run on hmc : viosvrcmd -m FRAME  -p VIOSERVER2 -c "mkvdev -fbo -dev hmut9_cdrom -vadapter vhost18"
# command to run on hmc : viosvrcmd -m FRAME -p VIOSERVER2 -c "mkvdev -fbo -dev _cdrom -vadapter vhost24"

As you know, an LPAR cannot having lparid equals to 0 :-)

With the modification i propose, the problem do not occur anymore.
