### PR TITLE
Update2 : vopt_manager.pl

### DIFF
--- a/vopt_manager.pl
+++ b/vopt_manager.pl
@@ -184,6 +184,7 @@ sub parse_lsmap {
     if ( $line =~ /(vhost\d+):(0x[^:]+):([^:]+):/ ) {
       warn whoami() . " parse NO vopt mapping:" .  $line if $debug;
       my $lparid = sprintf("%d", hex($2));
+      next if defined($$refvoptmap{$lparid}{'vios'});
       $$refvoptmap{$lparid}{'vhost'} = $1;
       $$refvoptmap{$lparid}{'vios'} = $vios;
     }


### PR DESCRIPTION
Another modification i propose.

In parse_lsmap function, a key may be erased by the last element found for an lpar.

Example :
# command to run on hmc : viosvrcmd -m FRAME -p VIOSERVER2 -c "mkvdev -fbo -dev LPAR_cdrom -vadapter vhost18"

The script propose to create the cdrom onto the second vio. The existting entry mapped to he first VIO is erased.

This is due to the code in parse_lsmap that does not verify if a key is already present in the hashmap.

With the modification i propose :

next if defined($$refvoptmap{$lparid}{'vios'});

The problem do not occur anymore, the cdrom will be created onto the first VIO inserted in the hasmap during the inventory.
